### PR TITLE
Change behaviour to not post success if event is excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## v0.1.0
+* First version
+* Monitors `DEPENDENCY_MISSING` and `FAILURE` events only
+* Post to Slack
+
+## v0.2.0
+* Package structure updated
+
+## v0.2.1
+* Package changes for pypi
+
+## v0.2.3
+* Bugfix for monitoring tasks successful for retry of failed event
+* Allow control of number of messages to print in notifications using `max_print` 
+
+## v1.0.0
+* Allow running from command line
+* Don't send notification for recovered issues
+
+## v1.0.1
+* Fix bugfix with typo of `Failures` to `Failure`
+
+## v1.0.2
+* Add support for posting to slack with custom username using `username` option
+* Update pypi long description
+
+## v1.1.0
+* Refactor events and notification logic
+  * `events` control notification events too allowing exclusion of success notification

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 ## Luigi Monitor
 
+[![](https://img.shields.io/pypi/v/luigi-monitor.svg)](https://img.shields.io/pypi/v/luigi-monitor.svg)
+[![](https://img.shields.io/pypi/l/luigi-monitor.svg)](https://img.shields.io/pypi/l/luigi-monitor.svg)
+[![](https://img.shields.io/pypi/pyversions/luigi-monitor.svg)](https://img.shields.io/pypi/pyversions/luigi-monitor.svg)
+[![](https://img.shields.io/pypi/format/luigi-monitor.svg)](https://img.shields.io/pypi/format/luigi-monitor.svg)
+
+
 ![message](https://raw.github.com/hudl/luigi-monitor/master/message.png)
 
 Send summary messages of your Luigi jobs to Slack.
@@ -43,6 +49,25 @@ if __name__ == "__main__":
 
 ```
 
+Monitoring and notifying on various events:
+
+Currently supports: `SUCCESS`, `DEPENDENCY_MISSING`, and `FAILURE` 
+
+By default, all three of the above are monitored and notified on. If, `SUCCESS` event is monitored and 
+all tasks succeed then the notification text is "Job ran successfully" instead of listing _all_ 
+successful tasks. 
+
+```python
+import luigi
+from luigi_monitor import monitor
+
+...
+
+if __name__ == "__main__":
+    with monitor(slack_url=<your_slack_url>, events=['DEPENDENCY_MISSING', 'FAILURE']):
+        luigi.run(main_task_cls=MainClass)
+```
+
 Alternatively:
 
 `luigi-monitor --module path.to.module TaskName`
@@ -58,9 +83,5 @@ username=<string>
 
 This is a work in progress. Particularly, note that:
 
-* It only sends notifications for FAILURE and DEPENDENCY_MISSING
-events.
 * It only sends notifications via Slack
-* If you have more than 5 notifications in a category (FAILURE or
-DEPENDENCY_MISSING), it will notify you of that rather than posting
-a long list of errors.
+* Untested against Python3

--- a/luigi_monitor/luigi_monitor.py
+++ b/luigi_monitor/luigi_monitor.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import print_function
 import inspect
 import json
 import os
@@ -8,17 +10,22 @@ import luigi
 from luigi.retcodes import run_with_retcodes as run_luigi
 import requests
 
-events = {}
+const_success_message = "Job ran successfully!"
+
+
+class Monitor:
+    recorded_events = {}
+
 
 def discovered(task, dependency):
     raise NotImplementedError
 
 def missing(task):
     task = str(task)
-    if 'Missing' in events:
-        events['Missing'].append(task)
+    if 'Missing' in m.recorded_events:
+        m.recorded_events['Missing'].append(task)
     else:
-        events['Missing'] = [task]
+        m.recorded_events['Missing'] = [task]
 
 def present(task):
     raise NotImplementedError
@@ -32,19 +39,24 @@ def start(task):
 def failure(task, exception):
     task = str(task)
     failure = {'task': task, 'exception': str(exception)}
-    if 'Failure' in events:
-        events['Failure'].append(failure)
+    if 'Failure' in m.recorded_events:
+        m.recorded_events['Failure'].append(failure)
     else:
-        events['Failure'] = [failure]
+        m.recorded_events['Failure'] = [failure]
 
 def success(task):
     task = str(task)
-    if 'Failure' in events:
-        events['Failure'] = [failure for failure in events['Failure']
-                             if task not in failure['task']]
-    if 'Missing' in events:
-        events['Missing'] = [missing for missing in events['Missing']
-                             if task not in missing]
+    if 'Failure' in m.recorded_events:
+        m.recorded_events['Failure'] = [failure for failure in m.recorded_events['Failure']
+                                      if task not in failure['task']]
+    if 'Missing' in m.recorded_events:
+        m.recorded_events['Missing'] = [missing for missing in m.recorded_events['Missing']
+                                      if task not in missing]
+    if 'Success' in m.recorded_events:
+        m.recorded_events['Success'].append(task)
+    else:
+        m.recorded_events['Success'] = [task]
+
 
 def processing_time(task, time):
     raise NotImplementedError
@@ -74,45 +86,52 @@ def set_handlers(events):
 def format_message(max_print):
     job = os.path.basename(inspect.stack()[-1][1])
     text = ["Status report for {}".format(job)]
-    if 'Failure' in events and len(events['Failure']) > 0:
+    if 'Failure' in m.recorded_events and len(m.recorded_events['Failure']) > 0:
         text.append("*Failures:*")
-        if len(events['Failure']) > max_print:
+        if len(m.recorded_events['Failure']) > max_print:
             text.append("More than %d failures. Please check logs." % max_print)
         else:
-            for failure in events['Failure']:
+            for failure in m.recorded_events['Failure']:
                 text.append("Task: {}; Exception: {}".format(failure['task'], failure['exception']))
-    if 'Missing' in events and len(events['Missing']) > 0:
+    if 'Missing' in m.recorded_events and len(m.recorded_events['Missing']) > 0:
         text.append("*Tasks with missing dependencies:*")
-        if len(events['Missing']) > max_print:
+        if len(m.recorded_events['Missing']) > max_print:
             text.append("More than %d tasks with missing dependencies. Please check logs." % max_print)
         else:
-            for missing in events['Missing']:
+            for missing in m.recorded_events['Missing']:
                 text.append(missing)
-    if len(text) == 1:
-        text.append("Job ran successfully!")
-    text = "\n".join(text)
-    return text
+    # if job successful add success message
+    if len(m.recorded_events) == 1 and 'Success' in m.recorded_events and len(m.recorded_events['Success']) > 0:
+        text.append(const_success_message)
+    formatted_text = "\n".join(text)
+    if formatted_text == text[0]:
+        return False
+    return formatted_text
 
 def send_message(slack_url, max_print, username=None):
     text = format_message(max_print)
-    if not slack_url:
-        print "slack_url not provided. Message will not be sent"
-        print text
+    if not slack_url and text:
+        print("slack_url not provided. Message will not be sent")
+        print(text)
         return False
-    payload = {"text": text}
-    if username:
-        payload['username'] = username
-    r = requests.post(slack_url, data=json.dumps(payload))
-    if not r.status_code == 200:
-        raise Exception(r.text)
+    if text:
+        payload = {"text": text}
+        if username:
+            payload['username'] = username
+        r = requests.post(slack_url, data=json.dumps(payload))
+        if not r.status_code == 200:
+            raise Exception(r.text)
     return True
+
+m = Monitor()
 
 @contextmanager
 def monitor(events=['FAILURE', 'DEPENDENCY_MISSING', 'SUCCESS'], slack_url=None, max_print=5, username=None):
+    
     if events:
-        h = set_handlers(events)
-    yield
-    m = send_message(slack_url, max_print, username)
+        set_handlers(events)
+    yield m
+    send_message(slack_url, max_print, username)
 
 def run():
     """Command line entry point for luigi-monitor"""

--- a/luigi_monitor/luigi_monitor.py
+++ b/luigi_monitor/luigi_monitor.py
@@ -1,9 +1,9 @@
 from __future__ import print_function
-from __future__ import print_function
 import inspect
 import json
 import os
 import sys
+from collections import defaultdict
 from contextlib import contextmanager
 
 import luigi
@@ -14,52 +14,65 @@ const_success_message = "Job ran successfully!"
 
 
 class Monitor:
-    recorded_events = {}
+    recorded_events = defaultdict(list)
+    notify_events = None
+
+    def is_success_only(self):
+        success_only = True
+        for k, i in self.recorded_events.items():
+            if k == 'SUCCESS' and len(i) > 0:
+                success_only = success_only and True
+            elif len(i) > 0:
+                success_only = success_only and False
+                break
+        return success_only
+
+    def has_missing_tasks(self):
+        return True if self.recorded_events['DEPENDENCY_MISSING'] else False
+
+    def has_failed_tasks(self):
+        return True if self.recorded_events['FAILURE'] else False
 
 
 def discovered(task, dependency):
     raise NotImplementedError
 
+
 def missing(task):
     task = str(task)
-    if 'Missing' in m.recorded_events:
-        m.recorded_events['Missing'].append(task)
-    else:
-        m.recorded_events['Missing'] = [task]
+    m.recorded_events['DEPENDENCY_MISSING'].append(task)
+
 
 def present(task):
     raise NotImplementedError
 
+
 def broken(task, exception):
     raise NotImplementedError
+
 
 def start(task):
     raise NotImplementedError
 
+
 def failure(task, exception):
     task = str(task)
     failure = {'task': task, 'exception': str(exception)}
-    if 'Failure' in m.recorded_events:
-        m.recorded_events['Failure'].append(failure)
-    else:
-        m.recorded_events['Failure'] = [failure]
+    m.recorded_events['Failure'].append(failure)
+
 
 def success(task):
     task = str(task)
-    if 'Failure' in m.recorded_events:
-        m.recorded_events['Failure'] = [failure for failure in m.recorded_events['Failure']
-                                      if task not in failure['task']]
-    if 'Missing' in m.recorded_events:
-        m.recorded_events['Missing'] = [missing for missing in m.recorded_events['Missing']
-                                      if task not in missing]
-    if 'Success' in m.recorded_events:
-        m.recorded_events['Success'].append(task)
-    else:
-        m.recorded_events['Success'] = [task]
+    m.recorded_events['FAILURE'] = [failure for failure in m.recorded_events['FAILURE']
+                                    if task not in failure['task']]
+    m.recorded_events['DEPENDENCY_MISSING'] = [missing for missing in m.recorded_events['DEPENDENCY_MISSING']
+                                    if task not in missing]
+    m.recorded_events['SUCCESS'].append(task)
 
 
 def processing_time(task, time):
     raise NotImplementedError
+
 
 event_map = {
     "DEPENDENCY_DISCOVERED": {"function": discovered, "handler": luigi.Event.DEPENDENCY_DISCOVERED},
@@ -72,6 +85,7 @@ event_map = {
     "PROCESSING_TIME": {"function": processing_time, "handler": luigi.Event.PROCESSING_TIME}
 }
 
+
 def set_handlers(events):
     if not isinstance(events, list):
         raise Exception("events must be a list")
@@ -83,30 +97,35 @@ def set_handlers(events):
         function = event_map[event]['function']
         luigi.Task.event_handler(handler)(function)
 
+
 def format_message(max_print):
     job = os.path.basename(inspect.stack()[-1][1])
     text = ["Status report for {}".format(job)]
-    if 'Failure' in m.recorded_events and len(m.recorded_events['Failure']) > 0:
+    if m.has_failed_tasks() and 'FAILURE' in m.notify_events:
         text.append("*Failures:*")
-        if len(m.recorded_events['Failure']) > max_print:
+        if len(m.recorded_events['FAILURE']) > max_print:
             text.append("More than %d failures. Please check logs." % max_print)
         else:
-            for failure in m.recorded_events['Failure']:
+            for failure in m.recorded_events['FAILURE']:
                 text.append("Task: {}; Exception: {}".format(failure['task'], failure['exception']))
-    if 'Missing' in m.recorded_events and len(m.recorded_events['Missing']) > 0:
+    if m.has_missing_tasks() and 'DEPENDENCY_MISSING' in m.notify_events:
         text.append("*Tasks with missing dependencies:*")
-        if len(m.recorded_events['Missing']) > max_print:
+        if len(m.recorded_events['DEPENDENCY_MISSING']) > max_print:
             text.append("More than %d tasks with missing dependencies. Please check logs." % max_print)
         else:
-            for missing in m.recorded_events['Missing']:
+            for missing in m.recorded_events['DEPENDENCY_MISSING']:
                 text.append(missing)
     # if job successful add success message
-    if len(m.recorded_events) == 1 and 'Success' in m.recorded_events and len(m.recorded_events['Success']) > 0:
+    if m.is_success_only() and 'SUCCESS' in m.notify_events:
         text.append(const_success_message)
     formatted_text = "\n".join(text)
     if formatted_text == text[0]:
         return False
     return formatted_text
+
+
+
+
 
 def send_message(slack_url, max_print, username=None):
     text = format_message(max_print)
@@ -123,15 +142,18 @@ def send_message(slack_url, max_print, username=None):
             raise Exception(r.text)
     return True
 
+
 m = Monitor()
+
 
 @contextmanager
 def monitor(events=['FAILURE', 'DEPENDENCY_MISSING', 'SUCCESS'], slack_url=None, max_print=5, username=None):
-    
     if events:
+        m.notify_events = events
         set_handlers(events)
     yield m
     send_message(slack_url, max_print, username)
+
 
 def run():
     """Command line entry point for luigi-monitor"""
@@ -142,6 +164,7 @@ def run():
         run_luigi(sys.argv[1:])
     except SystemExit:
         send_message(slack_url, max_print, username)
+
 
 def parse_config():
     """Parse luigi-monitor config"""

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 setup(
     name="luigi-monitor",
-    version="1.0.2",
+    version="1.1.0",
     description="Send summary messages of your Luigi jobs to Slack.",
     long_description=open("README.md").read(),
     url="https://github.com/hudl/luigi-monitor",

--- a/tests/luigi.cfg
+++ b/tests/luigi.cfg
@@ -1,0 +1,2 @@
+[core]
+lock_size=5

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,77 @@
+# All tests pass successfully individually but not as a suite
+import luigi
+from luigi_monitor import monitor
+import unittest
+import os
+import mock
+import requests
+import inspect
+
+
+class TestMissingTask(luigi.ExternalTask):
+
+    def output(self):
+        return luigi.LocalTarget('dummy.txt')
+
+
+class TestSuccessTask(luigi.Task):
+    num = luigi.Parameter()
+
+    def output(self):
+        return luigi.LocalTarget('words.txt')
+
+    def run(self):
+        # write a dummy list of words to output file
+        words = [
+            'apple',
+            'banana',
+            'grapefruit'
+        ]
+
+        with self.output().open('w') as f:
+            for word in words:
+                f.write('{word}\n'.format(word=word))
+
+
+# This method will be used by the mock to replace requests.get
+def mocked_requests_post(*args, **kwargs):
+    resp = mock.Mock(spec=requests.Response)
+    resp.status_code = 200
+    return resp
+
+
+class TestLuigiMonitor(unittest.TestCase):
+    @mock.patch('requests.post', side_effect=mocked_requests_post)
+    def test_monitor_no_message(self, mock_post):
+        with monitor(slack_url='mock://slack', events=['DEPENDENCY_MISSING']) as m:
+            luigi.run(main_task_cls=TestSuccessTask, local_scheduler=True, cmdline_args=['--num', '1'])
+            self.assertDictEqual(m.recorded_events, {})
+        self.assertEqual(mock_post.call_count, 0, 'Slack webhook called')
+
+    @mock.patch('requests.post', side_effect=mocked_requests_post)
+    def test_monitor_missing_message(self, mock_post):
+        with monitor(slack_url='mock://slack', events=['DEPENDENCY_MISSING']) as m:
+            luigi.run(main_task_cls=TestMissingTask, local_scheduler=True, cmdline_args=[])
+            self.assertDictEqual(m.recorded_events, {'Missing': ['TestMissingTask()']})
+        call_data = mock_post.call_args[1]['data']
+        call_url = mock_post.call_args[0][0]
+        expected = '{"text": "Status report for ' + os.path.basename(inspect.stack()[-1][1]) + '\\n' \
+                                                                                               '*Tasks with missing dependencies:*' \
+                                                                                               '\\n' \
+                                                                                               'TestMissingTask()"}'
+        self.assertEqual(call_data, expected)
+
+    @mock.patch('requests.post', side_effect=mocked_requests_post)
+    def test_monitor_success_message(self, mock_post):
+        with monitor(slack_url='mock://slack') as m:
+            luigi.run(main_task_cls=TestSuccessTask, local_scheduler=True, cmdline_args=['--num', '2'])
+            self.assertDictEqual(m.recorded_events, {'Success': ['TestSuccessTask(num=2)']})
+        call_data = mock_post.call_args[1]['data']
+        call_url = mock_post.call_args[0][0]
+        expected = '{"text": "Status report for ' + os.path.basename(
+            inspect.stack()[-1][1]) + '\\nJob ran successfully!"}'
+        self.assertEqual(call_data, expected)
+
+    def tearDown(self):
+        if os.path.isfile('words.txt'):
+            os.remove('words.txt')


### PR DESCRIPTION
Ref: #13 
Returns a monitor object with `recorded_events` property so that the events can be accessed outside. useful for testing too. 
Success handler adds events to recorded events so notify only if `SUCCESS` is added to events.

Tests are added. They pass individually. luigi locks and shared state with local scheduler result in errors