### PR TITLE
fixed typo for addressing failures in recorded_events dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,6 @@
 ## v1.1.0
 * Refactor events and notification logic
   * `events` control notification events too allowing exclusion of success notification
+
+## v1.1.1
+*  fixed typo for addressing failures in recorded_events dict `Failure` -> `FAILURE`

--- a/luigi_monitor/luigi_monitor.py
+++ b/luigi_monitor/luigi_monitor.py
@@ -58,7 +58,7 @@ def start(task):
 def failure(task, exception):
     task = str(task)
     failure = {'task': task, 'exception': str(exception)}
-    m.recorded_events['Failure'].append(failure)
+    m.recorded_events['FAILURE'].append(failure)
 
 
 def success(task):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 setup(
     name="luigi-monitor",
-    version="1.1.0",
+    version="1.1.1",
     description="Send summary messages of your Luigi jobs to Slack.",
     long_description=open("README.md").read(),
     url="https://github.com/hudl/luigi-monitor",


### PR DESCRIPTION
since the key for event type FAILURE is always all caps, it also needs be all caps, when the dict recorded_events will be filled with events of this event type.