### PR TITLE
Set notify events for commandline run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,6 @@
 
 ## v1.1.1
 *  fixed typo for addressing failures in recorded_events dict `Failure` -> `FAILURE`
+
+## v1.1.2
+* set notify_events when running luigi-monitor from commandline

--- a/luigi_monitor/luigi_monitor.py
+++ b/luigi_monitor/luigi_monitor.py
@@ -159,6 +159,7 @@ def run():
     """Command line entry point for luigi-monitor"""
     events = ['FAILURE', 'DEPENDENCY_MISSING', 'SUCCESS']
     slack_url, max_print, username = parse_config()
+    m.notify_events = events
     set_handlers(events)
     try:
         run_luigi(sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 setup(
     name="luigi-monitor",
-    version="1.1.1",
+    version="1.1.2",
     description="Send summary messages of your Luigi jobs to Slack.",
     long_description=open("README.md").read(),
     url="https://github.com/hudl/luigi-monitor",


### PR DESCRIPTION
otherwise it would be empty and cannot be evaluated in format_message method.